### PR TITLE
fix: replace `stream-concat` with `combined-stream2`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "app-builder": "^5.0.1",
     "bluebird": "^3.3.5",
     "char-spinner": "^1.0.1",
+    "combined-stream2": "^1.1.2",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "progress": "^1.1.8",
-    "stream-concat": "^0.1.0",
     "tar": "^2.2.1"
   },
   "devDependencies": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,7 +3,7 @@ import { Promise, promisify } from 'bluebird'
 import { createWriteStream, readFile } from 'fs'
 import { argv } from './options'
 import { Readable } from 'stream'
-import StreamConcat from 'stream-concat'
+import { create as createCombinedStream } from 'combined-stream2'
 
 const readFileAsync = promisify(readFile),
   isWindows = process.platform === 'win32',
@@ -52,8 +52,10 @@ async function cli (compiler, next) {
 
   const deliverable = await compiler.getDeliverableAsync(),
     inputStream = new Readable(),
-    outputStream = new StreamConcat([deliverable, inputStream])
+    outputStream = createCombinedStream()
 
+  outputStream.append(deliverable)
+  outputStream.append(inputStream)
   inputStream.push(xbinStart + compiler.input + xbinEnd)
   inputStream.push(null)
 


### PR DESCRIPTION
While running xbin along side other CPU intensive build processes, I noticed that the combined `deliverable` stream and `inputStream` did not always output correctly.  `stream-concat` seems to randomly stop piping data when it gets to the last chunk of the `deliverable` stream, and does not pipe through the data from `inputStream`.  I replaced it with `combined-stream2` and am no longer seeing the issue. 