### PR TITLE
fix: replace `stream-concat` with `multistream`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "char-spinner": "^1.0.1",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
+    "multistream": "^2.1.0",
     "progress": "^1.1.8",
-    "stream-concat": "^0.1.0",
     "tar": "^2.2.1"
   },
   "devDependencies": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,7 +3,7 @@ import { Promise, promisify } from 'bluebird'
 import { createWriteStream, readFile } from 'fs'
 import { argv } from './options'
 import { Readable } from 'stream'
-import StreamConcat from 'stream-concat'
+import combineStreams from 'multistream'
 
 const readFileAsync = promisify(readFile),
   isWindows = process.platform === 'win32',
@@ -52,7 +52,7 @@ async function cli (compiler, next) {
 
   const deliverable = await compiler.getDeliverableAsync(),
     inputStream = new Readable(),
-    outputStream = new StreamConcat([deliverable, inputStream])
+    outputStream = combineStreams([deliverable, inputStream])
 
   inputStream.push(xbinStart + compiler.input + xbinEnd)
   inputStream.push(null)


### PR DESCRIPTION
While running xbin along side other CPU intensive build processes, I noticed that the combined `deliverable` stream and `inputStream` did not always output correctly. `stream-concat` seems to randomly stop piping data when it gets to the last chunk of the `deliverable` stream, and does not pipe through the data from `inputStream`. I replaced it with `multistream` and am no longer seeing the issue.